### PR TITLE
Fix all_on and all_off error

### DIFF
--- a/src/board.js
+++ b/src/board.js
@@ -69,14 +69,17 @@ class Board {
   }
 
   allOn() {
-    this.trigger([ALL_ON])
+    this.trigger([ALL_ON, 0])
   }
 
   allOff() {
-    this.trigger([ALL_OFF])
+    this.trigger([ALL_OFF, 0])
   }
 
   trigger(state) {
+    if (state.length != 2) {
+      throw new Error('easy-usb-relay library error: exactly two arguments required for trigger function.')
+    }
     this.logState()
     this.board.sendFeatureReport(state)
   }


### PR DESCRIPTION
sendFeatureReport always needs two arguments, even if one is null (0x00)

See C++ source here for future development reference: https://github.com/pavel-a/usb-relay-hid/blob/87cf2d92c7b64b02f870b86a55ee9c970c29abdd/lib/usb_relay_lib.c